### PR TITLE
Align watermark flow with port configuration

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -822,11 +822,13 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
                     auto queues = tokens[1];
-                    if (op == SET_COMMAND && flexCounterOrch->getQueueCountersState())
+                    if (op == SET_COMMAND &&
+                        (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
                         gPortsOrch->createPortBufferQueueCounters(port, queues);
                     }
-                    else if (op == DEL_COMMAND && flexCounterOrch->getQueueCountersState())
+                    else if (op == DEL_COMMAND &&
+                             (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
                         gPortsOrch->removePortBufferQueueCounters(port, queues);
                     }
@@ -841,23 +843,23 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
              * so we added a map that will help us to know what was the last command for this port and priority -
              * if the last command was set command then it is a modify command and we dont need to increase the buffer counter
              * all other cases (no last command exist or del command was the last command) it means that we need to increase the ref counter */
-            if (op == SET_COMMAND) 
+            if (op == SET_COMMAND)
             {
-                if (queue_port_flags[port_name][ind] != SET_COMMAND) 
+                if (queue_port_flags[port_name][ind] != SET_COMMAND)
                 {
                     /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
                     gPortsOrch->increasePortRefCount(port_name);
                 }
-            } 
+            }
             else if (op == DEL_COMMAND)
             {
-                if (queue_port_flags[port_name][ind] == SET_COMMAND) 
+                if (queue_port_flags[port_name][ind] == SET_COMMAND)
 		{
                     /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
                     gPortsOrch->decreasePortRefCount(port_name);
                 }
-            } 
-            else 
+            }
+            else
             {
                 SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
                 return task_process_status::task_invalid_entry;
@@ -1001,11 +1003,13 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                     {
                         auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
                         auto pgs = tokens[1];
-                        if (op == SET_COMMAND && flexCounterOrch->getPgWatermarkCountersState())
+                        if (op == SET_COMMAND &&
+                            (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
                         {
                             gPortsOrch->createPortBufferPgCounters(port, pgs);
                         }
-                        else if (op == DEL_COMMAND && flexCounterOrch->getPgWatermarkCountersState())
+                        else if (op == DEL_COMMAND &&
+                                 (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
                         {
                             gPortsOrch->removePortBufferPgCounters(port, pgs);
                         }
@@ -1021,23 +1025,23 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
              * so we added a map that will help us to know what was the last command for this port and priority -
              * if the last command was set command then it is a modify command and we dont need to increase the buffer counter
              * all other cases (no last command exist or del command was the last command) it means that we need to increase the ref counter */
-            if (op == SET_COMMAND) 
+            if (op == SET_COMMAND)
             {
-                if (pg_port_flags[port_name][ind] != SET_COMMAND) 
+                if (pg_port_flags[port_name][ind] != SET_COMMAND)
                 {
                     /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
                     gPortsOrch->increasePortRefCount(port_name);
                 }
-            } 
+            }
             else if (op == DEL_COMMAND)
             {
-                if (pg_port_flags[port_name][ind] == SET_COMMAND) 
+                if (pg_port_flags[port_name][ind] == SET_COMMAND)
                 {
                     /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
                     gPortsOrch->decreasePortRefCount(port_name);
                 }
-            } 
-            else 
+            }
+            else
             {
                 SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
                 return task_process_status::task_invalid_entry;

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -29,7 +29,9 @@ extern FlowCounterRouteOrch *gFlowCounterRouteOrch;
 #define PORT_KEY                    "PORT"
 #define PORT_BUFFER_DROP_KEY        "PORT_BUFFER_DROP"
 #define QUEUE_KEY                   "QUEUE"
+#define QUEUE_WATERMARK             "QUEUE_WATERMARK"
 #define PG_WATERMARK_KEY            "PG_WATERMARK"
+#define PG_DROP_KEY                 "PG_DROP"
 #define RIF_KEY                     "RIF"
 #define ACL_KEY                     "ACL"
 #define TUNNEL_KEY                  "TUNNEL"
@@ -162,11 +164,25 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         {
                             gPortsOrch->generateQueueMap(getQueueConfigurations());
                             m_queue_enabled = true;
+                            gPortsOrch->addQueueFlexCounters(getQueueConfigurations());
+                        }
+                        else if(key == QUEUE_WATERMARK)
+                        {
+                            gPortsOrch->generateQueueMap(getQueueConfigurations());
+                            m_queue_watermark_enabled = true;
+                            gPortsOrch->addQueueWatermarkFlexCounters(getQueueConfigurations());
+                        }
+                        else if(key == PG_DROP_KEY)
+                        {
+                            gPortsOrch->generatePriorityGroupMap(getPgConfigurations());
+                            m_pg_enabled = true;
+                            gPortsOrch->addPriorityGroupFlexCounters(getPgConfigurations());
                         }
                         else if(key == PG_WATERMARK_KEY)
                         {
                             gPortsOrch->generatePriorityGroupMap(getPgConfigurations());
                             m_pg_watermark_enabled = true;
+                            gPortsOrch->addPriorityGroupWatermarkFlexCounters(getPgConfigurations());
                         }
                     }
                     if(gIntfsOrch && (key == RIF_KEY) && (value == "enable"))
@@ -250,14 +266,24 @@ bool FlexCounterOrch::getPortBufferDropCountersState() const
     return m_port_buffer_drop_counter_enabled;
 }
 
-bool FlexCounterOrch::getPgWatermarkCountersState() const
-{
-    return m_pg_watermark_enabled;
-}
-
 bool FlexCounterOrch::getQueueCountersState() const
 {
     return m_queue_enabled;
+}
+
+bool FlexCounterOrch::getQueueWatermarkCountersState() const
+{
+    return m_queue_watermark_enabled;
+}
+
+bool FlexCounterOrch::getPgCountersState() const
+{
+    return m_pg_enabled;
+}
+
+bool FlexCounterOrch::getPgWatermarkCountersState() const
+{
+    return m_pg_watermark_enabled;
 }
 
 bool FlexCounterOrch::bake()

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -42,8 +42,10 @@ public:
     virtual ~FlexCounterOrch(void);
     bool getPortCountersState() const;
     bool getPortBufferDropCountersState() const;
-    bool getPgWatermarkCountersState() const;
     bool getQueueCountersState() const;
+    bool getQueueWatermarkCountersState() const;
+    bool getPgCountersState() const;
+    bool getPgWatermarkCountersState() const;
     std::map<std::string, FlexCounterQueueStates> getQueueConfigurations();
     std::map<std::string, FlexCounterPgStates> getPgConfigurations();
     bool getHostIfTrapCounterState() const {return m_hostif_trap_counter_enabled;}
@@ -57,8 +59,10 @@ private:
     shared_ptr<ProducerTable> m_gbflexCounterGroupTable = nullptr;
     bool m_port_counter_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
-    bool m_pg_watermark_enabled = false;
     bool m_queue_enabled = false;
+    bool m_queue_watermark_enabled = false;
+    bool m_pg_enabled = false;
+    bool m_pg_watermark_enabled = false;
     bool m_hostif_trap_counter_enabled = false;
     bool m_route_flow_counter_enabled = false;
     Table m_flexCounterConfigTable;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6058,7 +6058,6 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
 void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq)
 {
     /* Create the Queue map in the Counter DB */
-    /* Add stat counters to flex_counter */
     vector<FieldValueTuple> queueVector;
     vector<FieldValueTuple> queuePortVector;
     vector<FieldValueTuple> queueIndexVector;
@@ -6112,35 +6111,6 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
         {
             queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
         }
-
-        // Install a flex counter for this queue to track stats
-        std::unordered_set<string> counter_stats;
-        for (const auto& it: queue_stat_ids)
-        {
-            counter_stats.emplace(sai_serialize_queue_stat(it));
-        }
-        queue_stat_manager.setCounterIdList(queue_ids[queueIndex], CounterType::QUEUE, counter_stats);
-
-        if (voq)
-        {
-           continue;
-        }
-
-        /* add watermark queue counters */
-        string key = getQueueWatermarkFlexCounterTableKey(id);
-
-        string delimiter("");
-        std::ostringstream counters_stream;
-        for (const auto& it: queueWatermarkStatIds)
-        {
-            counters_stream << delimiter << sai_serialize_queue_stat(it);
-            delimiter = comma;
-        }
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(QUEUE_COUNTER_ID_LIST, counters_stream.str());
-
-        m_flexCounterTable->set(key, fieldValues);
     }
 
     if (voq)
@@ -6151,7 +6121,6 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
     {
         m_queueTable->set("", queueVector);
     }
-
     m_queuePortTable->set("", queuePortVector);
     m_queueIndexTable->set("", queueIndexVector);
     m_queueTypeTable->set("", queueTypeVector);
@@ -6159,12 +6128,129 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
     CounterCheckOrch::getInstance().addPort(port);
 }
 
+void PortsOrch::addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector)
+{
+    if (m_isQueueFlexCountersAdded)
+    {
+        return;
+    }
+
+    for (const auto& it: m_portList)
+    {
+        if (it.second.m_type == Port::PHY)
+        {
+            if (!queuesStateVector.count(it.second.m_alias))
+            {
+                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
+                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
+            }
+            addQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
+        }
+    }
+
+    m_isQueueFlexCountersAdded = true;
+}
+
+
+void PortsOrch::addQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState)
+{
+    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
+    {
+        string queueType;
+        uint8_t queueRealIndex = 0;
+        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
+        {
+            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
+            {
+                continue;
+            }
+            // Install a flex counter for this queue to track stats
+            addQueueFlexCountersPerPortPerQueueIndex(port, queueIndex);
+        }
+    }
+}
+
+void PortsOrch::addQueueFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex)
+{
+    std::unordered_set<string> counter_stats;
+    for (const auto& it: queue_stat_ids)
+    {
+        counter_stats.emplace(sai_serialize_queue_stat(it));
+    }
+    queue_stat_manager.setCounterIdList(port.m_queue_ids[queueIndex], CounterType::QUEUE, counter_stats);
+}
+
+
+void PortsOrch::addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector)
+{
+    if (m_isQueueWatermarkFlexCountersAdded)
+    {
+        return;
+    }
+
+    for (const auto& it: m_portList)
+    {
+        if (it.second.m_type == Port::PHY)
+        {
+            if (!queuesStateVector.count(it.second.m_alias))
+            {
+                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
+                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
+            }
+            addQueueWatermarkFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
+        }
+    }
+
+    m_isQueueWatermarkFlexCountersAdded = true;
+}
+
+void PortsOrch::addQueueWatermarkFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState)
+{
+    /* Add stat counters to flex_counter */
+
+    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
+    {
+        string queueType;
+        uint8_t queueRealIndex = 0;
+        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
+        {
+            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
+            {
+                continue;
+            }
+            addQueueWatermarkFlexCountersPerPortPerQueueIndex(port, queueIndex);
+        }
+    }
+}
+
+void PortsOrch::addQueueWatermarkFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex)
+{
+    const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
+
+    /* add watermark queue counters */
+    string key = getQueueWatermarkFlexCounterTableKey(id);
+
+    string delimiter("");
+    std::ostringstream counters_stream;
+    for (const auto& it: queueWatermarkStatIds)
+    {
+        counters_stream << delimiter << sai_serialize_queue_stat(it);
+        delimiter = comma;
+    }
+
+    vector<FieldValueTuple> fieldValues;
+    fieldValues.emplace_back(QUEUE_COUNTER_ID_LIST, counters_stream.str());
+
+    m_flexCounterTable->set(key, fieldValues);
+}
+
 void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
 {
     SWSS_LOG_ENTER();
 
     /* Create the Queue map in the Counter DB */
-    /* Add stat counters to flex_counter */
     vector<FieldValueTuple> queueVector;
     vector<FieldValueTuple> queuePortVector;
     vector<FieldValueTuple> queueIndexVector;
@@ -6196,29 +6282,17 @@ void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
         queueVector.emplace_back(name.str(), id);
         queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
 
-        // Install a flex counter for this queue to track stats
-        std::unordered_set<string> counter_stats;
-        for (const auto& it: queue_stat_ids)
+        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+        if (flexCounterOrch->getQueueCountersState())
         {
-            counter_stats.emplace(sai_serialize_queue_stat(it));
+            // Install a flex counter for this queue to track stats
+            addQueueFlexCountersPerPortPerQueueIndex(port, queueIndex);
         }
-        queue_stat_manager.setCounterIdList(port.m_queue_ids[queueIndex], CounterType::QUEUE, counter_stats);
-
-        /* add watermark queue counters */
-        string key = getQueueWatermarkFlexCounterTableKey(id);
-
-        string delimiter("");
-        std::ostringstream counters_stream;
-        for (const auto& it: queueWatermarkStatIds)
+        if (flexCounterOrch->getQueueWatermarkCountersState())
         {
-            counters_stream << delimiter << sai_serialize_queue_stat(it);
-            delimiter = comma;
+            /* add watermark queue counters */
+            addQueueWatermarkFlexCountersPerPortPerQueueIndex(port, queueIndex);
         }
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(QUEUE_COUNTER_ID_LIST, counters_stream.str());
-
-        m_flexCounterTable->set(key, fieldValues);
     }
 
     m_queueTable->set("", queueVector);
@@ -6261,12 +6335,19 @@ void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
             m_queueIndexTable->hdel("", id);
         }
 
-        // Remove the flex counter for this queue
-        queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
+        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+        if (flexCounterOrch->getQueueCountersState())
+        {
+            // Remove the flex counter for this queue
+            queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
+        }
 
-        // Remove watermark queue counters
-        string key = getQueueWatermarkFlexCounterTableKey(id);
-        m_flexCounterTable->del(key);
+        if (flexCounterOrch->getQueueWatermarkCountersState())
+        {
+            // Remove watermark queue counters
+            string key = getQueueWatermarkFlexCounterTableKey(id);
+            m_flexCounterTable->del(key);
+        }
     }
 
     CounterCheckOrch::getInstance().removePort(port);
@@ -6299,7 +6380,6 @@ void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsSta
 void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
 {
     /* Create the PG map in the Counter DB */
-    /* Add stat counters to flex_counter */
     vector<FieldValueTuple> pgVector;
     vector<FieldValueTuple> pgPortVector;
     vector<FieldValueTuple> pgIndexVector;
@@ -6319,36 +6399,6 @@ void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgS
         pgPortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
         pgIndexVector.emplace_back(id, to_string(pgIndex));
 
-        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-
-        std::string delimiter = "";
-        std::ostringstream counters_stream;
-        /* Add watermark counters to flex_counter */
-        for (const auto& it: ingressPriorityGroupWatermarkStatIds)
-        {
-            counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-            delimiter = comma;
-        }
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(PG_COUNTER_ID_LIST, counters_stream.str());
-        m_flexCounterTable->set(key, fieldValues);
-
-        delimiter = "";
-        std::ostringstream ingress_pg_drop_packets_counters_stream;
-        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-        /* Add dropped packets counters to flex_counter */
-        for (const auto& it: ingressPriorityGroupDropStatIds)
-        {
-            ingress_pg_drop_packets_counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-            if (delimiter.empty())
-            {
-                delimiter = comma;
-            }
-        }
-        fieldValues.clear();
-        fieldValues.emplace_back(PG_COUNTER_ID_LIST, ingress_pg_drop_packets_counters_stream.str());
-        m_flexCounterTable->set(key, fieldValues);
     }
 
     m_pgTable->set("", pgVector);
@@ -6387,36 +6437,17 @@ void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
         pgPortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
         pgIndexVector.emplace_back(id, to_string(pgIndex));
 
-        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-
-        std::string delimiter = "";
-        std::ostringstream counters_stream;
-        /* Add watermark counters to flex_counter */
-        for (const auto& it: ingressPriorityGroupWatermarkStatIds)
+        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+        if (flexCounterOrch->getPgCountersState())
         {
-            counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-            delimiter = comma;
+            /* Add dropped packets counters to flex_counter */
+            addPriorityGroupFlexCountersPerPortPerPgIndex(port, pgIndex);
         }
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(PG_COUNTER_ID_LIST, counters_stream.str());
-        m_flexCounterTable->set(key, fieldValues);
-
-        delimiter = "";
-        std::ostringstream ingress_pg_drop_packets_counters_stream;
-        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-        /* Add dropped packets counters to flex_counter */
-        for (const auto& it: ingressPriorityGroupDropStatIds)
+        if (flexCounterOrch->getPgWatermarkCountersState())
         {
-            ingress_pg_drop_packets_counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-            if (delimiter.empty())
-            {
-                delimiter = comma;
-            }
+            /* Add watermark counters to flex_counter */
+            addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(port, pgIndex);
         }
-        fieldValues.clear();
-        fieldValues.emplace_back(PG_COUNTER_ID_LIST, ingress_pg_drop_packets_counters_stream.str());
-        m_flexCounterTable->set(key, fieldValues);
     }
 
     m_pgTable->set("", pgVector);
@@ -6424,6 +6455,121 @@ void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
     m_pgIndexTable->set("", pgIndexVector);
 
     CounterCheckOrch::getInstance().addPort(port);
+}
+
+void PortsOrch::addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pgsStateVector)
+{
+    if (m_isPriorityGroupFlexCountersAdded)
+    {
+        return;
+    }
+
+    for (const auto& it: m_portList)
+    {
+        if (it.second.m_type == Port::PHY)
+        {
+            if (!pgsStateVector.count(it.second.m_alias))
+            {
+                auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
+                FlexCounterPgStates flexCounterPgState(maxPgNumber);
+                pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
+            }
+            addPriorityGroupFlexCountersPerPort(it.second, pgsStateVector.at(it.second.m_alias));
+        }
+    }
+
+    m_isPriorityGroupFlexCountersAdded = true;
+}
+
+void PortsOrch::addPriorityGroupFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState)
+{
+    for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
+    {
+        if (!pgsState.isPgCounterEnabled(static_cast<uint32_t>(pgIndex)))
+        {
+            continue;
+        }
+        addPriorityGroupFlexCountersPerPortPerPgIndex(port, pgIndex);
+    }
+}
+
+void PortsOrch::addPriorityGroupFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex)
+{
+    const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
+
+    string delimiter = "";
+    std::ostringstream ingress_pg_drop_packets_counters_stream;
+    string key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
+    /* Add dropped packets counters to flex_counter */
+    for (const auto& it: ingressPriorityGroupDropStatIds)
+    {
+        ingress_pg_drop_packets_counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
+        if (delimiter.empty())
+        {
+            delimiter = comma;
+        }
+    }
+    vector<FieldValueTuple> fieldValues;
+    fieldValues.emplace_back(PG_COUNTER_ID_LIST, ingress_pg_drop_packets_counters_stream.str());
+    m_flexCounterTable->set(key, fieldValues);
+}
+
+void PortsOrch::addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgStates> pgsStateVector)
+{
+    if (m_isPriorityGroupWatermarkFlexCountersAdded)
+    {
+        return;
+    }
+
+    for (const auto& it: m_portList)
+    {
+        if (it.second.m_type == Port::PHY)
+        {
+            if (!pgsStateVector.count(it.second.m_alias))
+            {
+                auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
+                FlexCounterPgStates flexCounterPgState(maxPgNumber);
+                pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
+            }
+            addPriorityGroupWatermarkFlexCountersPerPort(it.second, pgsStateVector.at(it.second.m_alias));
+        }
+    }
+
+    m_isPriorityGroupWatermarkFlexCountersAdded = true;
+}
+
+void PortsOrch::addPriorityGroupWatermarkFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState)
+{
+    /* Add stat counters to flex_counter */
+
+    for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
+    {
+        if (!pgsState.isPgCounterEnabled(static_cast<uint32_t>(pgIndex)))
+        {
+            continue;
+        }
+        addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(port, pgIndex);
+    }
+}
+
+void PortsOrch::addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex)
+{
+    const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
+
+    string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
+
+    std::string delimiter = "";
+    std::ostringstream counters_stream;
+    /* Add watermark counters to flex_counter */
+    for (const auto& it: ingressPriorityGroupWatermarkStatIds)
+    {
+        counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
+        delimiter = comma;
+    }
+
+    vector<FieldValueTuple> fieldValues;
+    fieldValues.emplace_back(PG_COUNTER_ID_LIST, counters_stream.str());
+    m_flexCounterTable->set(key, fieldValues);
 }
 
 void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
@@ -6451,13 +6597,20 @@ void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
         m_pgPortTable->hdel("", id);
         m_pgIndexTable->hdel("", id);
 
-        // Remove dropped packets counters from flex_counter
-        string key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-        m_flexCounterTable->del(key);
+        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+        if (flexCounterOrch->getPgCountersState())
+        {
+            // Remove dropped packets counters from flex_counter
+            string key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
+            m_flexCounterTable->del(key);
+        }
 
-        // Remove watermark counters from flex_counter
-        key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-        m_flexCounterTable->del(key);
+        if (flexCounterOrch->getPgWatermarkCountersState())
+        {
+            // Remove watermark counters from flex_counter
+            string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
+            m_flexCounterTable->del(key);
+        }
     }
 
     CounterCheckOrch::getInstance().removePort(port);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -130,16 +130,20 @@ public:
 
     bool setPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t pfc_bitmask);
     bool getPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t *pfc_bitmask);
-    
+
     void generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector);
     uint32_t getNumberOfPortSupportedQueueCounters(string port);
     void createPortBufferQueueCounters(const Port &port, string queues);
     void removePortBufferQueueCounters(const Port &port, string queues);
+    void addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
+    void addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
 
     void generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector);
     uint32_t getNumberOfPortSupportedPgCounters(string port);
     void createPortBufferPgCounters(const Port &port, string pgs);
     void removePortBufferPgCounters(const Port& port, string pgs);
+    void addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pgsStateVector);
+    void addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgStates> pgsStateVector);
 
     void generatePortCounterMap();
     void generatePortBufferDropCounterMap();
@@ -357,8 +361,24 @@ private:
 
     bool m_isQueueMapGenerated = false;
     void generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq);
+    bool m_isQueueFlexCountersAdded = false;
+    void addQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState);
+    void addQueueFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex);
+
+    bool m_isQueueWatermarkFlexCountersAdded = false;
+    void addQueueWatermarkFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState);
+    void addQueueWatermarkFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex);
+
     bool m_isPriorityGroupMapGenerated = false;
     void generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState);
+    bool m_isPriorityGroupFlexCountersAdded = false;
+    void addPriorityGroupFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState);
+    void addPriorityGroupFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex);
+
+    bool m_isPriorityGroupWatermarkFlexCountersAdded = false;
+    void addPriorityGroupWatermarkFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState);
+    void addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex);
+
     bool m_isPortCounterMapGenerated = false;
     bool m_isPortBufferDropCounterMapGenerated = false;
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Align watermark flow with port configuration
correct the queue, watermark and pg-drop counterpoll functionality according to cli commands

**Why I did it**
the flow before this commit was wrong, when watermark counterpoll was enabled, stats wasn't created in FLEX_COUNTERS_DB
and COUNTERS_DB unless enabling queue counterpoll as well.
in the same way when pg-drop counterpoll was enabled stats weren't added until watermark was enabled.
This is due to the wrong flow where queue and pg maps were generated only when queue or watermark (pg-watermark)
key was detected in flexcountersorch.cpp

**How I verified it**
manual testing
VS test (updated to reflect current flow) - before this commit only queue was tested
regression test

**Details if related**
